### PR TITLE
Listen on port 8080

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -16,5 +16,5 @@ RUN envsubst '$REGISTRY_VERSION' < /etc/nginx/nginx.conf.tmp > /etc/nginx/nginx.
     && rm /etc/nginx/nginx.conf.tmp \
     && chmod -R 777 /var/log/nginx /var/cache/nginx/ /var/run/ \
     && chmod 644 /etc/nginx/*
-
+PORT 8080
 COPY ./json/ /usr/share/nginx/html/


### PR DESCRIPTION
Since nginx configuration is listening on port 8080 but the container do not advertise that port, deploying on Openshift Online fail since Openshift use 80 by default