### PR TITLE
Remove vaadin extension

### DIFF
--- a/extensions/vaadin.yaml
+++ b/extensions/vaadin.yaml
@@ -1,6 +1,0 @@
----
-group-id: "com.vaadin"
-artifact-id: "vaadin-quarkus"
-versions:
-- "1.0.0"
-exclude-versions: []


### PR DESCRIPTION
This PR removes the vaadin extension from the registry until the remaining issues are sorted out