### PR TITLE
Rename quarkiverse-logging-json to quarkus-logging-json

### DIFF
--- a/extensions/quarkiverse-logging-json.yaml
+++ b/extensions/quarkiverse-logging-json.yaml
@@ -1,6 +1,3 @@
 ---
 group-id: "io.quarkiverse.loggingjson"
-artifact-id: "quarkiverse-logging-json"
-versions:
-- "0.2.3"
-- "0.1.7"
+artifact-id: "quarkus-logging-json"


### PR DESCRIPTION
We were still pointing to the old extension.