### PR TITLE
Retire quarkiverse-apicurio-registry-client

### DIFF
--- a/extensions/quarkiverse-apicurio-registry-client.yaml
+++ b/extensions/quarkiverse-apicurio-registry-client.yaml
@@ -1,5 +1,0 @@
----
-group-id: "io.quarkiverse.apicurio"
-artifact-id: "quarkiverse-apicurio-registry-client"
-versions:
-- "0.0.2"


### PR DESCRIPTION
Per discussion with Clément and Ladislav.

@gastaldi I would appreciate if you could drop it from the database afterwards.