### PR TITLE
Store opt-ins for naming companies as sponsors on extensions.quarkus.io

### DIFF
--- a/named-contributing-orgs-opt-in.yml
+++ b/named-contributing-orgs-opt-in.yml
@@ -1,0 +1,6 @@
+# This file is to record opt-ins for companies and organisations to be listed as sponsors and contributors on extension pages
+# See https://quarkus.io/extensions/io.quarkus/quarkus-resteasy-reactive for an example of what is shown
+
+# Including a company in this list should be done (or approved) by someone from that company
+named-sponsors:
+  - Red Hat


### PR DESCRIPTION
See https://github.com/quarkiverse/quarkiverse/pull/182 for discussion.

I renamed the file a bit to make it clear(ish) it was for institutions, and not people. Although 'orgs' kind of implies GitHub orgs, not companies, so maybe it should be `contributing-companies-opt-in.yml`?

I wondered about putting it in a folder, but even once we show the companies in a pie chart, I'm planning to have it all in one file, so a folder for one file seemed like overkill. Also, I couldn't decide what to name the folder. :)