### PR TITLE
Add new list for contributing companies

### DIFF
--- a/named-contributing-orgs-opt-in.yml
+++ b/named-contributing-orgs-opt-in.yml
@@ -5,3 +5,8 @@
 named-sponsors:
   - Red Hat
   - Microsoft
+
+# Any organisation that opts in as a sponsor will also be shown on charts of contributors
+# To be shown in the charts, but *not* ever listed as a sponsor, an organisation should add its name to this list
+named-contributing-orgs:
+  - Made Up Example Company

--- a/named-contributing-orgs-opt-in.yml
+++ b/named-contributing-orgs-opt-in.yml
@@ -1,11 +1,18 @@
 # This file is to record opt-ins for companies and organisations to be listed as sponsors and contributors on extension pages
 # See https://quarkus.io/extensions/io.quarkus/quarkus-resteasy-reactive for an example of what is shown
 
-# Including a company in this list should be done (or approved) by someone from that company
+# Including a company in these list should be done (or approved) by someone from that company
+
+# What's a sponsor? A sponsor is an organisation or group of organisations that make a big enough contribution to an extension that they're sponsoring it.
+# A sponsor can be listed in an individual extension's `quarkus-extension.yml`, but if there isn't one there, we try to guess.
+# We won't show a guess without an opt-in, which is the function of this list.
 named-sponsors:
   - Red Hat
   - Microsoft
 
+# Most extensions have contributions from *many* organisations, which is the beauty of open source communities.
+# Not every contributing company is a sponsor, but we also want to list every contributing organisation.
+# We won't list an organisation without an opt-in.
 # Any organisation that opts in as a sponsor will also be shown on charts of contributors
 # To be shown in the charts, but *not* ever listed as a sponsor, an organisation should add its name to this list
 named-contributing-orgs:


### PR DESCRIPTION
Before I extend https://github.com/quarkusio/extensions/pull/368 to show organisations, I'd like there to be some organisations in the list. To do that, we need opt-ins, and to do that, we need a place to opt in. I think this structure makes sense, although I'm not thrilled with how long the name is. 