### PR TITLE
Add quarkus-hilla-react extension

### DIFF
--- a/extensions/quarkus-hilla-react.yaml
+++ b/extensions/quarkus-hilla-react.yaml
@@ -1,0 +1,2 @@
+group-id: com.github.mcollovati
+artifact-id: quarkus-hilla-react


### PR DESCRIPTION
quarkus-hilla-react is a companion extension for quarkus-hilla, targeting React for front-end development