### PR TITLE
Add Citrus extension

### DIFF
--- a/extensions/citrus.yaml
+++ b/extensions/citrus.yaml
@@ -1,0 +1,6 @@
+---
+group-id: "org.citrusframework"
+artifact-id: "citrus-quarkus"
+versions:
+- "4.1.0"
+exclude-versions: []


### PR DESCRIPTION
- Citrus is an Open Source Java test framework for automated integration testing with focus on messaging
- The extension enables the combination of Citrus and QuarkusTest