### PR TITLE
Quarkus XMLSec moved to Quarkus CXF

### DIFF
--- a/extensions/quarkiverse-xmlsec.yaml
+++ b/extensions/quarkiverse-xmlsec.yaml
@@ -1,8 +1,0 @@
----
-group-id: "io.quarkiverse.xmlsec"
-artifact-id: "quarkus-xmlsec"
-versions:
-- "1.1.1"
-- "1.0.0"
-- "0.0.1"
-exclude-versions: []


### PR DESCRIPTION
Santuario XMLSec will be awailable under Quarkus CXF starting with Quarkus 3.8. I am sending this PR following the advice of @gastaldi 