### PR TITLE
Include Azure Key Vault service in the registry

### DIFF
--- a/extensions/quarkiverse-azure-keyvault.yaml
+++ b/extensions/quarkiverse-azure-keyvault.yaml
@@ -1,0 +1,2 @@
+group-id: io.quarkiverse.azureservices
+artifact-id: quarkus-azure-keyvault


### PR DESCRIPTION
Hello @gastaldi , we just released [quarkus-azure-services 1.0.3](https://github.com/quarkiverse/quarkus-azure-services/releases/tag/1.0.3) which delivered a new extension `quarkus-azure-keyvault`. Would you pls review the PR that adds it to Quarkus registry? Cc @galiacheng @edburns @backwind1233

Reference PR https://github.com/quarkusio/quarkus-extension-catalog/pull/64.