### PR TITLE
Include Azure Cosmos DB extension in the registry

### DIFF
--- a/extensions/quarkiverse-azure-cosmos.yaml
+++ b/extensions/quarkiverse-azure-cosmos.yaml
@@ -1,0 +1,2 @@
+group-id: io.quarkiverse.azureservices
+artifact-id: quarkus-azure-cosmos


### PR DESCRIPTION
Hello @gastaldi , we just released [quarkus-azure-services 1.0.7](https://github.com/quarkiverse/quarkus-azure-services/releases/tag/1.0.7) which delivered a new extension `quarkus-azure-cosmos`. Would you pls review the PR that adds it to Quarkus registry? Cc @galiacheng @edburns @backwind1233