### PR TITLE
Extension relocation : quarkus-messaging-nats-jetstream

### DIFF
--- a/extensions/quarkiverse-messaging-nats-jetstream.yaml
+++ b/extensions/quarkiverse-messaging-nats-jetstream.yaml
@@ -1,0 +1,6 @@
+---
+group-id: "io.quarkiverse.reactivemessaging.nats-jetstream"
+artifact-id: "quarkus-messaging-nats-jetstream"
+versions:
+- "1.12.1"
+exclude-versions: []

--- a/extensions/quarkiverse-reactive-messaging-nats-jetstream.yaml
+++ b/extensions/quarkiverse-reactive-messaging-nats-jetstream.yaml
@@ -1,8 +1,8 @@
 ---
 group-id: "io.quarkiverse.reactivemessaging.nats-jetstream"
 artifact-id: "quarkus-reactive-messsaging-nats-jetstream"
+enabled: false
 versions:
-- "1.12.1"
 - "1.11.0"
 - "1.10.5"
 - "1.9.5"


### PR DESCRIPTION
Created a new entry to the catalog for `quarkus-messaging-nats-jetstream` and disabled the old one: `quarkus-reactive-messsaging-nats-jetstream`