### PR TITLE
Manually add Beta2 release

### DIFF
--- a/extensions/quarkiverse-couchbase.yaml
+++ b/extensions/quarkiverse-couchbase.yaml
@@ -3,5 +3,4 @@ group-id: "io.quarkiverse.couchbase"
 artifact-id: "quarkus-couchbase"
 versions:
 - "1.0.0.Beta2"
-- "1.0.0.Beta1"
 exclude-versions: []

--- a/extensions/quarkiverse-couchbase.yaml
+++ b/extensions/quarkiverse-couchbase.yaml
@@ -2,5 +2,6 @@
 group-id: "io.quarkiverse.couchbase"
 artifact-id: "quarkus-couchbase"
 versions:
+- "1.0.0.Beta2"
 - "1.0.0.Beta1"
 exclude-versions: []


### PR DESCRIPTION
Adding our `1.0.0.Beta2` release, which fixes the guide link in the extension metadata (and some docs changes) as the workflow doesn't pick up pre-releases.