### PR TITLE
Add 3.8 to LTS list

### DIFF
--- a/platforms/quarkus-bom.yaml
+++ b/platforms/quarkus-bom.yaml
@@ -41,6 +41,8 @@ exclude-versions:
 - "2.0.3.Final"
 pinned-streams:
 - "3.2"
+- "3.8"
+- "3.15"
 lts-streams:
 - "3.2"
 - "3.8"

--- a/platforms/quarkus-bom.yaml
+++ b/platforms/quarkus-bom.yaml
@@ -43,4 +43,5 @@ pinned-streams:
 - "3.2"
 lts-streams:
 - "3.2"
+- "3.8"
 - "3.15"


### PR DESCRIPTION
For the sake of completeness I feel the LTS list should also mention 3.8. What about the pinned streams?