### PR TITLE
Unpin 3.2 and 3.8 releases

### DIFF
--- a/platforms/quarkus-bom.yaml
+++ b/platforms/quarkus-bom.yaml
@@ -12,7 +12,6 @@ versions:
 - "3.17.8"
 - "3.16.4"
 - "3.15.4"
-- "3.15.3"
 exclude-versions:
 - "3.15.3.1"
 - "3.15.0"
@@ -50,8 +49,6 @@ exclude-versions:
 - "2.1.4.Final"
 - "2.0.3.Final"
 pinned-streams:
-- "3.2"
-- "3.8"
 - "3.15"
 - "3.20"
 lts-streams:


### PR DESCRIPTION
This will avoid returning the 3.2 and 3.8 streams from the list of available platforms