### PR TITLE
Include Azure Service Bus extension in the registry

### DIFF
--- a/extensions/quarkiverse-azure-servicebus.yaml
+++ b/extensions/quarkiverse-azure-servicebus.yaml
@@ -1,0 +1,2 @@
+group-id: io.quarkiverse.azureservices
+artifact-id: quarkus-azure-servicebus


### PR DESCRIPTION
Hello @gastaldi , we just released [quarkus-azure-services 1.1.5](https://github.com/quarkiverse/quarkus-azure-services/releases/tag/1.1.5) which delivered a new extension `quarkus-azure-servicebus`. Would you pls review the PR that adds it to Quarkus registry? Cc @edburns @backwind1233 @albers