### PR TITLE
Add Roq 2.1.0.CR1 and missing Roq extensions

### DIFF
--- a/extensions/quarkiverse-roq-data.yaml
+++ b/extensions/quarkiverse-roq-data.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-data"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-editor.yaml
+++ b/extensions/quarkiverse-roq-editor.yaml
@@ -1,0 +1,6 @@
+---
+group-id: "io.quarkiverse.roq"
+artifact-id: "quarkus-roq-editor"
+versions:
+- "2.1.0.CR1"
+exclude-versions: []

--- a/extensions/quarkiverse-roq-frontmatter.yaml
+++ b/extensions/quarkiverse-roq-frontmatter.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-frontmatter"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-generator.yaml
+++ b/extensions/quarkiverse-roq-generator.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-generator"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-aliases.yaml
+++ b/extensions/quarkiverse-roq-plugin-aliases.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-aliases"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-asciidoc-jruby.yaml
+++ b/extensions/quarkiverse-roq-plugin-asciidoc-jruby.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-asciidoc-jruby"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-asciidoc.yaml
+++ b/extensions/quarkiverse-roq-plugin-asciidoc.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-asciidoc"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-diagram.yaml
+++ b/extensions/quarkiverse-roq-plugin-diagram.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-diagram"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-faker.yaml
+++ b/extensions/quarkiverse-roq-plugin-faker.yaml
@@ -1,0 +1,7 @@
+---
+group-id: "io.quarkiverse.roq"
+artifact-id: "quarkus-roq-plugin-faker"
+versions:
+- "2.1.0.CR1"
+- "2.0.5"
+exclude-versions: []

--- a/extensions/quarkiverse-roq-plugin-lunr.yaml
+++ b/extensions/quarkiverse-roq-plugin-lunr.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-lunr"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-markdown.yaml
+++ b/extensions/quarkiverse-roq-plugin-markdown.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-markdown"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-qrcode.yaml
+++ b/extensions/quarkiverse-roq-plugin-qrcode.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-qrcode"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-series.yaml
+++ b/extensions/quarkiverse-roq-plugin-series.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-series"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-sitemap.yaml
+++ b/extensions/quarkiverse-roq-plugin-sitemap.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-sitemap"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-plugin-tagging.yaml
+++ b/extensions/quarkiverse-roq-plugin-tagging.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq-plugin-tagging"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"

--- a/extensions/quarkiverse-roq-theme-default.yaml
+++ b/extensions/quarkiverse-roq-theme-default.yaml
@@ -1,0 +1,6 @@
+---
+group-id: "io.quarkiverse.roq"
+artifact-id: "quarkus-roq-theme-default"
+versions:
+- "2.1.0.CR1"
+exclude-versions: []

--- a/extensions/quarkiverse-roq-theme-resume.yaml
+++ b/extensions/quarkiverse-roq-theme-resume.yaml
@@ -1,0 +1,7 @@
+---
+group-id: "io.quarkiverse.roq"
+artifact-id: "quarkus-roq-theme-resume"
+versions:
+- "2.1.0.CR1"
+- "2.0.5"
+exclude-versions: []

--- a/extensions/quarkiverse-roq.yaml
+++ b/extensions/quarkiverse-roq.yaml
@@ -2,6 +2,7 @@
 group-id: "io.quarkiverse.roq"
 artifact-id: "quarkus-roq"
 versions:
+- "2.1.0.CR1"
 - "2.0.5"
 - "1.10.3"
 - "1.9.0"


### PR DESCRIPTION
- Add `2.1.0.CR1` to all existing Roq extensions
- Add 4 new Roq extensions to the catalog: `roq-theme-default`, `roq-theme-resume`, `roq-plugin-faker`, `roq-editor`