### PR TITLE
Add Roq linktree theme and hybrid plugin

### DIFF
--- a/extensions/quarkiverse-roq-plugin-hybrid.yaml
+++ b/extensions/quarkiverse-roq-plugin-hybrid.yaml
@@ -1,0 +1,6 @@
+---
+group-id: "io.quarkiverse.roq"
+artifact-id: "quarkus-roq-plugin-hybrid"
+versions:
+- "2.1.5"
+exclude-versions: []

--- a/extensions/quarkiverse-roq-theme-linktree.yaml
+++ b/extensions/quarkiverse-roq-theme-linktree.yaml
@@ -1,0 +1,6 @@
+---
+group-id: "io.quarkiverse.roq"
+artifact-id: "quarkus-roq-theme-linktree"
+versions:
+- "2.1.5"
+exclude-versions: []


### PR DESCRIPTION
## Summary

- Add `quarkus-roq-theme-linktree` (linktree theme for Roq)
- Add `quarkus-roq-plugin-hybrid` (hybrid mode plugin for Roq)

Both were released in Roq 2.1.5.