### PR TITLE
Add quarkus-morphium (de.caluga) as an external extension

### DIFF
--- a/extensions/morphium.yaml
+++ b/extensions/morphium.yaml
@@ -1,0 +1,7 @@
+---
+group-id: "de.caluga"
+artifact-id: "quarkus-morphium"
+versions:
+- "6.3.1"
+- "6.3.0"
+exclude-versions: []


### PR DESCRIPTION
## Add quarkus-morphium (de.caluga) as an external extension

`quarkus-morphium` is a Quarkus extension for [Morphium](https://github.com/sboesebeck/morphium),
a Java MongoDB ODM. Since Morphium 6.3.0 the extension is part of the main Morphium reactor
(`de.caluga:quarkus-morphium`), replacing an earlier standalone/Quarkiverse-adjacent repo that saw
little traffic.

- Maven coordinates: `de.caluga:quarkus-morphium`, published to Central since 6.3.0.
- CDI producer, type-safe `@ConfigMapping` configuration, `@MorphiumTransactional` declarative
  transactions with CDI lifecycle events, Dev Services (auto-starting MongoDB, optionally as a
  replica set), MicroProfile health checks, GraalVM native-image support.
- Full [Jakarta Data 1.0](https://jakarta.ee/specifications/data/1.0/) `@Repository` support via
  build-time Gizmo bytecode generation (query derivation, JDQL, `Page`/`CursoredPage` pagination,
  `Stream`/`CompletionStage` async queries) — a working MongoDB provider for the spec, not a
  partial implementation.
- Migration Runner (`@MorphiumChangeUnit`/`@Execution`/`@RollbackExecution`) with a changelog and
  distributed lock, for versioned schema/data migrations.
- Documentation: an Antora module in the reactor
  ([`quarkus-morphium/docs/`](https://github.com/sboesebeck/morphium/tree/develop/quarkus-morphium/docs))
  plus a runnable [showcase application](https://github.com/Bardioc1977/quarkus-morphium-showcase)
  demonstrating every feature end to end.

`extensions/morphium.yaml` added per the third-party extension convention (own group ID, not
`io.quarkiverse`, per [the Quarkiverse onboarding guidelines](https://github.com/quarkiverse/quarkiverse/wiki)).
