### PR TITLE
Add io.github.pimak:ntfy-quarkus-runtime (ntfy logging extension)

### DIFF
--- a/extensions/ntfy-logging.yaml
+++ b/extensions/ntfy-logging.yaml
@@ -1,0 +1,6 @@
+---
+group-id: "io.github.pimak"
+artifact-id: "ntfy-quarkus-runtime"
+versions:
+- "2.0.0"
+exclude-versions: []


### PR DESCRIPTION
Adds the Quarkus extension from [ntfy-logging](https://github.com/Pimak/ntfy-logging) to the catalog.

It publishes ERROR/SEVERE log events as [ntfy](https://ntfy.sh) push notifications, exposes a generic ntfy client for arbitrary notifications, and reports the alert pipeline's counters to Micrometer when it is present. The extension installs its log handler through `LogHandlerBuildItem`, so alerting is live before the CDI container exists, and it builds its HTTP client at runtime-init for GraalVM native images.

Checklist against the requirements in the README:

- [x] Released to a Maven repository — `io.github.pimak:ntfy-quarkus-runtime` is on Maven Central, versions 1.0.0 through 2.0.0.
- [x] Built with at least Quarkus 1.13.0.Final — built against Quarkus 3.38.1.
- [x] Ships `META-INF/quarkus-extension.yaml` with name, description, keywords, categories, status and guide.

Only 2.0.0 is declared here; earlier 1.x releases are omitted deliberately, as 2.0.0 is the current supported line.

Native mode is covered in CI: the extension's integration tests are GraalVM-native-compiled and run against the native binary on every build.
